### PR TITLE
Include package.json in Bower distributable

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -23,7 +23,7 @@ module.exports = {
       dest: '<%= paths.dist %>assets/scss/',
       filter: 'isFile'
     },{
-      src: 'bower.json',
+      src: ['bower.json', 'package.json'],
       dest: '<%= paths.dist %>assets/'
     }]
   }


### PR DESCRIPTION
Module distribution was already discussed a little in #4710, but I'd like to kick-start one portion of it: make Foundation installable via npm. (My use case: I'm attempting to wean myself off Bower and install everything via npm)

[npm allows Git repositories to be used as endpoints](https://docs.npmjs.com/files/package.json#github-urls), but the repo requires a `package.json` file to function. This commit simply copies the existing `package.json` file into `dist/assets`.

You could publish specifically to npm but it's not strictly necessary (perhaps wait until F6?). For now, one could install Foundation with this configuration:

```
"dependencies": {
  "foundation": "zurb/bower-foundation"
}
```